### PR TITLE
fix(mjolnir): ensure keymap exists during customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report issues with the RC at: https://github.com/b-vitamins/mjolnir/issues
 ### Fixed
 - Byte compilation error when loading due to early use of `mjolnir-mode-map`
+  and `mjolnir--define-key`
 
 ## [0.4.0-rc1] - 2025-06-11
 ### ⚠️ Release Candidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Notes
 - v0.4.0 final release pending CI stabilization and testing feedback
 - Report issues with the RC at: https://github.com/b-vitamins/mjolnir/issues
+### Fixed
+- Byte compilation error when loading due to early use of `mjolnir-mode-map`
 
 ## [0.4.0-rc1] - 2025-06-11
 ### ⚠️ Release Candidate
@@ -65,7 +67,7 @@ The API is stable, but implementation details may change based on testing feedba
 
 ### Performance
 - Smart caching system for window angles
-- Frame-local buffer visibility tracking  
+- Frame-local buffer visibility tracking
 - Lazy evaluation and cache invalidation
 - Reduced memory allocation through state reuse
 - Sub-linear scaling with window count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Notes
 - v0.4.0 final release pending CI stabilization and testing feedback
 - Report issues with the RC at: https://github.com/b-vitamins/mjolnir/issues
+### Added
+- Helper macros for tests to create temporary buffers and handle frame failures
 ### Fixed
 - Byte compilation error when loading due to early use of `mjolnir-mode-map`
   and `mjolnir--define-key`
+- Test suite no longer fails when terminal frames cannot be created
 
 ## [0.4.0-rc1] - 2025-06-11
 ### ⚠️ Release Candidate

--- a/mjolnir.el
+++ b/mjolnir.el
@@ -97,10 +97,14 @@
 (require 'cl-lib)
 
 ;; Load core modules (byte-compiled but not separately installed)
-(let ((mjolnir-dir (file-name-directory (or load-file-name buffer-file-name))))
-  (add-to-list 'load-path (expand-file-name "core" mjolnir-dir))
-  (add-to-list 'load-path (expand-file-name "features" mjolnir-dir))
-  (add-to-list 'load-path (expand-file-name "ui" mjolnir-dir)))
+(eval-and-compile
+  (let ((mjolnir-dir (file-name-directory
+                      (or load-file-name
+                          byte-compile-current-file
+                          buffer-file-name))))
+    (add-to-list 'load-path (expand-file-name "core" mjolnir-dir))
+    (add-to-list 'load-path (expand-file-name "features" mjolnir-dir))
+    (add-to-list 'load-path (expand-file-name "ui" mjolnir-dir))))
 
 (require 'mjolnir-state)
 (require 'mjolnir-core)

--- a/mjolnir.el
+++ b/mjolnir.el
@@ -107,6 +107,11 @@
 (require 'mjolnir-windows)
 (require 'mjolnir-buffers)
 
+;;; Keymap
+
+(defvar mjolnir-mode-map (make-sparse-keymap)
+  "Keymap for `mjolnir-mode'.")
+
 ;;; Custom Variables
 
 (defgroup mjolnir nil
@@ -199,9 +204,6 @@ Used as custom setter for keybinding variables."
                              "Window is fixed")))))
 
 ;;; Keybinding Management
-
-(defvar mjolnir-mode-map (make-sparse-keymap)
-  "Keymap for `mjolnir-mode'.")
 
 (defun mjolnir--define-key (symbol value map)
   "Helper to update keybinding from SYMBOL to VALUE in MAP."


### PR DESCRIPTION
## Summary
- initialize `mjolnir-mode-map` before custom variables
- document fix in CHANGELOG

## Testing
- `pre-commit run --files mjolnir.el CHANGELOG.md`
- `make test` *(fails: emacs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684974b693f8832b95ce58e1bb8cd955